### PR TITLE
Copy `.lastIndex` to the cloned RegExp

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ module.exports = (regex, options) => {
 
 	const clonedRegexp = new RegExp(options.source || regex.source, flags);
 
-	clonedRegexp.lastIndex = (typeof options.lastIndex === 'number')
-		? options.lastIndex
-		: regex.lastIndex;
+	clonedRegexp.lastIndex = (typeof options.lastIndex === 'number') ?
+		options.lastIndex :
+		regex.lastIndex;
 
 	return clonedRegexp;
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,10 @@ module.exports = (regex, options) => {
 	)).join('');
 
 	const clonedRegexp = new RegExp(options.source || regex.source, flags);
-	clonedRegexp.lastIndex = regex.lastIndex;
+
+	clonedRegexp.lastIndex = (typeof options.lastIndex === 'number')
+		? options.lastIndex
+		: regex.lastIndex;
 
 	return clonedRegexp;
 };

--- a/index.js
+++ b/index.js
@@ -20,5 +20,8 @@ module.exports = (regex, options) => {
 		(typeof options[flag] === 'boolean' ? options[flag] : regex[flag]) ? flagMap[flag] : ''
 	)).join('');
 
-	return new RegExp(options.source || regex.source, flags);
+	const clonedRegexp = new RegExp(options.source || regex.source, flags);
+	clonedRegexp.lastIndex = regex.lastIndex;
+
+	return clonedRegexp;
 };

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = (regex, options) => {
 
 	const clonedRegexp = new RegExp(options.source || regex.source, flags);
 
-	clonedRegexp.lastIndex = (typeof options.lastIndex === 'number') ?
+	clonedRegexp.lastIndex = typeof options.lastIndex === 'number' ?
 		options.lastIndex :
 		regex.lastIndex;
 

--- a/test.js
+++ b/test.js
@@ -11,3 +11,14 @@ test('clone and modify RegExp', t => {
 		multiline: true
 	}).toString(), '/b/gim');
 });
+
+test('lastIndex is copied', t => {
+	const duckRe = /duck/g;
+
+	// Mutate duckRe by running 'test'
+	duckRe.test('duck duck goose');
+
+	const clonedDuckRe = m(duckRe);
+
+	t.is(duckRe.lastIndex, clonedDuckRe.lastIndex);
+});

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('clone and modify RegExp', t => {
 	}).toString(), '/b/gim');
 });
 
-test('lastIndex is copied', t => {
+test('lastIndex is copied by default', t => {
 	const duckRe = /duck/g;
 
 	// Mutate duckRe by running 'test'
@@ -20,5 +20,16 @@ test('lastIndex is copied', t => {
 
 	const clonedDuckRe = m(duckRe);
 
-	t.is(duckRe.lastIndex, clonedDuckRe.lastIndex);
+	t.is(clonedDuckRe.lastIndex, duckRe.lastIndex);
+});
+
+test('lastIndex can be configured via the options object', t => {
+	const duckRe = /duck/g;
+
+	// Mutate duckRe by running 'test'
+	duckRe.test('duck duck goose');
+
+	const clonedDuckRe = m(duckRe, {lastIndex: 0});
+
+	t.is(clonedDuckRe.lastIndex, 0);
 });


### PR DESCRIPTION
Been messing with cloning code and found this.  Feel free to tell me to modify styling e.g. variable names etc.

Maybe worth noting [clone prefaces the assignment with a truthy check](https://github.com/pvorb/clone/blob/master/clone.js#L103), but I couldn't find a reason to do that so I left it out.

Thanks as always for the library

---

Edit: I changed the title to WIP because I realized there's a possible ambiguity in terms of when someone might expect `lastIndex` to be copied.  I'm leaning toward wrapping the assignment in the following check:

```js
// We only want to copy lastIndex if we're truly cloning the regex
if (Object.keys(options).length === 0) {
    clonedRegexp.lastIndex = regex.lastIndex;
}
```

because a regex isn't really being cloned if any options are passed - the library acts more as a convenient constructor at that point.  Another solution would be to just make a note in the readme in case people expect `lastIndex` to be copied.